### PR TITLE
chore(github-actions): adding workflows for ci-check & publish

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -1,0 +1,20 @@
+name: ci-check
+
+on: [push, pull_request]
+
+jobs:
+  ci-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Run checks
+        run: yarn ci-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Publish to NPM
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          dry-run: true
+      - name: Create changelog
+        if: steps.publish.outputs.version != steps.publish.outputs['old-version']
+        env:
+          INPUT_TOKEN: ''
+        run: |
+          npm install -g conventional-changelog-cli
+          conventional-changelog -r 1 >> CHANGELOG.md
+      - name: Create Github Release
+        if: steps.publish.outputs.version != steps.publish.outputs['old-version']
+        uses: ncipollo/release-action@v1
+        with:
+          bodyFile: "CHANGELOG.md"
+          tag: v${{ steps.publish.outputs.version }}
+          commit: main
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+CHANGELOG.md
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "beacon": "lighthouse --config-path=src/config/custom-config.js",
+    "ci-check": "format:diff && lint:src",
     "format": "prettier --write '**/*.{js,md}'",
     "format:diff": "prettier --list-different '**/*.{js,md}'",
     "lint": "yarn lint:src && yarn lint:dist",


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5633

### Description

This adds the workflows to do ci-checks, as well as running a publish as
 soon as the package.json version is bumped up. This will also generate
 the changelog, then create the Github release.

### Changelog

**New**

- `publish.yml`
- `ci-check.yml`