### PR TITLE
feat(legal): check for legal links data-autoids

### DIFF
--- a/src/audits/legal/accessibility-link-audit.js
+++ b/src/audits/legal/accessibility-link-audit.js
@@ -42,7 +42,7 @@ class LegalLinksAudit extends Audit {
    */
   static audit(artifacts) {
     const loadMetrics = artifacts.CheckLegalLinks.filter((link) => {
-      return link.node.nodeLabel === 'Accessibility';
+      return link.dataAutoid === 'dds--footer-legal-nav__link-accessibility';
     });
 
     const hasAccessibility = loadMetrics.length !== 0;

--- a/src/audits/legal/privacy-link-audit.js
+++ b/src/audits/legal/privacy-link-audit.js
@@ -42,7 +42,7 @@ class LegalLinksAudit extends Audit {
    */
   static audit(artifacts) {
     const loadMetrics = artifacts.CheckLegalLinks.filter((link) => {
-      return link.node.nodeLabel === 'Privacy';
+      return link.dataAutoid === 'dds--footer-legal-nav__link-privacy';
     });
 
     const hasPrivacy = loadMetrics.length !== 0;

--- a/src/audits/legal/terms-of-use-link-audit.js
+++ b/src/audits/legal/terms-of-use-link-audit.js
@@ -42,7 +42,7 @@ class LegalLinksAudit extends Audit {
    */
   static audit(artifacts) {
     const loadMetrics = artifacts.CheckLegalLinks.filter((link) => {
-      return link.node.nodeLabel === 'Terms of use';
+      return link.dataAutoid === 'dds--footer-legal-nav__link-terms-of-use';
     });
 
     const hasTermsOfUse = loadMetrics.length !== 0;

--- a/src/gatherers/legal/legal-links-gatherer.js
+++ b/src/gatherers/legal/legal-links-gatherer.js
@@ -28,7 +28,9 @@ function getLegalLinksInDOM() {
 
     // check if the data-autoid is one of a legal link or specifically the cookie preferences link
     if (
-      dataAutoid === 'dds--footer-legal-nav__link' ||
+      dataAutoid === 'dds--footer-legal-nav__link-privacy' ||
+      dataAutoid === 'dds--footer-legal-nav__link-terms-of-use' ||
+      dataAutoid === 'dds--footer-legal-nav__link-accessibility' ||
       dataAutoid === 'dds--privacy-cp__link'
     ) {
       linkElements.push({


### PR DESCRIPTION
### Related Ticket(s)

[[Beacon for IBM.com] Create audits for the bucket "Legal" in Beacon #5939](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5939)

### Description

Set the audits and legal gather to check data-autoids rather than the link title which would fail if on a translated page.

### Changelog

**Changed**

- check autoids instead of link title

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
