### PR TITLE
feat(carbon-for-ibm-dotcom): created audits for bucket

### DIFF
--- a/src/audits/carbon-for-ibm-dotcom/callout-quote-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/callout-quote-audit.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Callout Quote quote uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Callout Quote quote does not use the recommended character count.',
+  description:
+    'The Callout Quote component has a recommended max amount of characters to be used in the quote. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/callout-quote#content-guidance).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxQuoteLength = 200;
+
+/**
+ * @file Audits if Callout Quote contains recommended amount of characters.
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'callout-quote-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadMetrics = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--callout-quote';
+    });
+
+    const hasCalloutQuote = loadMetrics.length !== 0;
+
+    // Callout Quote not found, audit not applicable
+    if (!hasCalloutQuote) {
+      return {
+        notApplicable: true,
+        rawValue: hasCalloutQuote,
+        score: Number(0),
+      };
+    }
+    const calloutQuoteText = loadMetrics[0].innerText
+      .split('\n')
+      .filter((e) => {
+        return e !== '';
+      });
+    const quote = calloutQuoteText[0].length;
+
+    // binary scoring
+    const score = quote <= maxQuoteLength ? 1 : 0;
+
+    return {
+      rawValue: hasCalloutQuote,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/card-copy-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/card-copy-audit.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title: 'Carbon for IBM.com Card copy uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Card copy does not use the recommended character count.',
+  description:
+    'The Card component has a recommended max amount of characters to be used in the copy. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/card).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxCopyLength = 200;
+
+/**
+ * @file Audits if Card has recommended character count for copy
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'card-copy-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadCard = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card';
+    });
+
+    // Card not found, audit not applicable
+    if (!loadCard[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    // Card found, extracting copy if it exists
+    const copy = loadCard[0].innerText.split('\n').filter((e) => {
+      return e !== '';
+    })[2];
+
+    // binary scoring
+    const score = copy && copy.length <= maxCopyLength ? 1 : 0;
+
+    return {
+      notApplicable: copy === undefined,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/card-eyebrow-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/card-eyebrow-audit.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Card eyebrow uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Card eyebrow does not use the recommended character count.',
+  description:
+    'The Card components have a recommended max amount of characters to be used in the eyebrow. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/card).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxEyebrowLength = 25;
+
+/**
+ * @file Audits if Card uses recommended character count for eyebrow
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'card-eyebrow-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadCard = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card';
+    });
+
+    const loadEyebrow = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card-eyebrow';
+    });
+
+    // Card not found, audit not applicable
+    if (!loadCard[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    const hasEyebrow = loadEyebrow.length !== 0;
+    const eyebrow = !hasEyebrow
+      ? loadCard[0].innerText.length
+      : loadEyebrow[0].innerText.length;
+
+    // binary scoring
+    const score = eyebrow <= maxEyebrowLength ? 1 : 0;
+
+    return {
+      rawValue: hasEyebrow,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/card-group-number-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/card-group-number-audit.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title: 'Carbon for IBM.com Card Group uses the recommended number of cards.',
+  failureTitle:
+    'Carbon for IBM.com Card Group does not use the recommended number of cards.',
+  description:
+    'The Card Group component has a recommended min/max number of cards to be included in the component. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/card-group).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const minCardTotal = 2;
+const maxCardTotal = 6;
+
+/**
+ * @file Audits if page's Card Group has recommended item limit
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'card-group-number-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadItems = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card-group-item';
+    });
+
+    if (!loadItems[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    const totalItems = loadItems.length;
+
+    // binary scoring
+    const score =
+      minCardTotal <= totalItems && totalItems <= maxCardTotal ? 1 : 0;
+
+    return {
+      rawValue: totalItems,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/card-heading-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/card-heading-audit.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Card heading uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Card heading does not use the recommended character count.',
+  description:
+    'The Card components have a recommended max amount of characters to be used in the heading. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/card).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxHeadingLength = 65;
+
+/**
+ * @file Audits if Card uses recommended character count for heading.
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'card-heading-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadCard = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card';
+    });
+
+    const loadHeading = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--card-heading';
+    });
+
+    // Card not found, audit not applicable
+    if (!loadCard[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    const hasHeading = loadHeading.length !== 0;
+    const heading = !hasHeading
+      ? loadCard[0].innerText.split('\n').filter((e) => {
+          return e !== '';
+        })[1].length
+      : loadHeading[0].innerText.length;
+
+    // binary scoring
+    const score = heading <= maxHeadingLength ? 1 : 0;
+
+    return {
+      rawValue: hasHeading,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/content-block-heading-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/content-block-heading-audit.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Content Block heading uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Content Block heading does not use the recommended character count.',
+  description:
+    'The Content Block components have a recommended max amount of characters to be used in the heading. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/content-block-simple#content-guidance).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxHeadingLength = 40;
+
+/**
+ * @file Audits if Content Block heading uses recommended amount of characters.
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'content-block-heading-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadMetrics = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--content-block__heading';
+    });
+
+    const hasContentBlockHeading = loadMetrics.length !== 0;
+    if (!hasContentBlockHeading) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+    const contentBlockHeading = loadMetrics[0].innerText.length;
+
+    // binary scoring
+    const score = contentBlockHeading <= maxHeadingLength ? 1 : 0;
+
+    return {
+      rawValue: hasContentBlockHeading,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/footer-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/footer-audit.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title: 'Carbon for IBM.com Footer component exists on the page',
+  failureTitle:
+    'Carbon for IBM.com Footer component does not exist on the page.',
+  description:
+    'The Footer component is a section that sits at the bottom of any IBM.com page, and acts as the catch—all section that helps users navigate and provides corporate level general and legal information. The footer is required on all pages on IBM.com. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/footer).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+/**
+ * @file Audits if page contains the Footer
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'footer-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadMetrics = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--footer';
+    });
+
+    const hasFooter = loadMetrics.length !== 0;
+
+    // binary scoring
+    const score = hasFooter ? 1 : 0;
+
+    return {
+      rawValue: hasFooter,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/leadspace-description-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/leadspace-description-audit.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Leadspace description uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Leadspace description does not use the recommended character count.',
+  description:
+    'The Leadspace component has a recommended max amount of characters to be used in the description. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/leadspace#content-guidance).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxDescriptionLength = 120;
+
+/**
+ * @file Audits if page contains the Leadspace description contains the appropiate amount of characters.
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'leadspace-description-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadLeadspace = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--leadspace';
+    });
+
+    const loadDescription = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--leadspace__description';
+    });
+
+    // Leadspace not found, audit not applicable
+    if (!loadLeadspace[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    const hasDescription = loadDescription.length !== 0;
+    const description = !hasDescription
+      ? loadLeadspace[0].innerText.split('\n').filter((e) => {
+          return e !== '';
+        })[1].length
+      : loadDescription[0].innerText.length;
+
+    // binary scoring
+    const score = description <= maxDescriptionLength ? 1 : 0;
+
+    return {
+      rawValue: hasDescription,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/leadspace-heading-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/leadspace-heading-audit.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title:
+    'Carbon for IBM.com Leadspace heading uses the recommended character count.',
+  failureTitle:
+    'Carbon for IBM.com Leadspace heading does not use the recommended character count.',
+  description:
+    'The Leadspace component has a recommended max amount of characters to be used in the heading. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/leadspace#content-guidance).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const maxHeadingLength = 65;
+
+/**
+ * @file Audits if Leadspace heading uses recommended amount of characters
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'leadspace-heading-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckComponents'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    const loadLeadspace = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--leadspace';
+    });
+
+    const loadHeading = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--leadspace-heading';
+    });
+
+    // Leadspace not found, audit not applicable
+    if (!loadLeadspace[0]) {
+      return {
+        notApplicable: true,
+        score: Number(0),
+      };
+    }
+
+    const hasHeading = loadHeading.length !== 0;
+    const heading = !hasHeading
+      ? loadLeadspace[0].innerText.split('\n')[0]
+      : loadHeading[0].innerText.length;
+
+    // binary scoring
+    const score = heading && heading <= maxHeadingLength ? 1 : 0;
+
+    return {
+      rawValue: hasHeading,
+      score: Number(score),
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/masthead-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/masthead-audit.js
@@ -7,14 +7,14 @@
 'use strict';
 
 const Audit = require('lighthouse').Audit;
-const i18n = require('../../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
 
 const UIStrings = {
-  title: 'Digital Data Object `version` property is set.',
+  title: 'Carbon for IBM.com Masthead component exists on the page',
   failureTitle:
-    'Digital Data Object Carbon for IBM.com `version` property is missing.',
+    'Carbon for IBM.com Masthead component does not exist on the page.',
   description:
-    'This property shows what Carbon for IBM.com package is being used on a page, as well as the version. This information can be helpful in troubleshooting bugs when authoring with Carbon for IBM.com packages. [Learn more](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/building-for-ibm-dotcom.md#digital-data-object).',
+    'The Masthead component is a fundamental navigational component for IBM.com that displays consistently at the top of each page. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/components/masthead).',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -22,18 +22,18 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 /**
  * @file Audits if page contains the IBM Digital Data Object (DDO)
  */
-class DDOAudit extends Audit {
+class CarbonForIBMDotcomAudit extends Audit {
   /**
    * @returns {*} {LH.Audit.Meta}
    */
   static get meta() {
     return {
-      id: 'ddo-version-audit',
+      id: 'masthead-audit',
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       // The name of the custom gatherer class that provides input to this audit.
-      requiredArtifacts: ['CheckDDO'],
+      requiredArtifacts: ['CheckComponents'],
     };
   }
 
@@ -42,17 +42,20 @@ class DDOAudit extends Audit {
    * @returns {*} Audit artifacts
    */
   static audit(artifacts) {
-    const loadMetrics = artifacts.CheckDDO.page.pageInfo.version;
-    const hasVersion = typeof loadMetrics !== 'undefined';
+    const loadMetrics = artifacts.CheckComponents.filter((link) => {
+      return link.dataAutoid === 'dds--masthead';
+    });
+
+    const hasMasthead = loadMetrics.length !== 0;
 
     // binary scoring
-    const score = hasVersion ? 1 : 0;
+    const score = hasMasthead ? 1 : 0;
 
     return {
-      rawValue: hasVersion,
+      rawValue: hasMasthead,
       score: Number(score),
     };
   }
 }
 
-module.exports = DDOAudit;
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/carbon-for-ibm-dotcom/v18-audit.js
+++ b/src/audits/carbon-for-ibm-dotcom/v18-audit.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+const i18n = require('../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
+
+const UIStrings = {
+  title: 'Northstar v18 not loaded in this page.',
+  failureTitle: 'Northstar v18 found in this page.',
+  description:
+    'Northstar v18 is currently planned to be sunset by the end of 2021, please start preparing to migrate to using Carbon for IBM.com. [Learn more](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/about/).',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+/**
+ * @file Audits if page contains Northstar v18 classes
+ */
+class CarbonForIBMDotcomAudit extends Audit {
+  /**
+   * @returns {*} {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'v18-audit',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // The name of the custom gatherer class that provides input to this audit.
+      requiredArtifacts: ['CheckV18'],
+    };
+  }
+
+  /**
+   * @param {object} artifacts Audit artifacts
+   * @returns {*} Audit artifacts
+   */
+  static audit(artifacts) {
+    if (!artifacts.CheckV18) {
+      return {
+        rawValue: true,
+        score: Number(1),
+      };
+    }
+
+    const totalClasses = artifacts.CheckV18.length;
+
+    const score = !totalClasses ? 1 : 0;
+    const displayString = totalClasses
+      ? `${totalClasses} v18 classes found`
+      : '';
+
+    return {
+      notApplicable: !artifacts.CheckV18,
+      rawValue: artifacts.CheckV18,
+      score: Number(score),
+      displayValue: displayString,
+    };
+  }
+}
+
+module.exports = CarbonForIBMDotcomAudit;

--- a/src/audits/page-data/ddo/ddo-version-check-audit.js
+++ b/src/audits/page-data/ddo/ddo-version-check-audit.js
@@ -10,14 +10,15 @@ const Audit = require('lighthouse').Audit;
 const i18n = require('../../../../node_modules/lighthouse/lighthouse-core/lib/i18n/i18n.js');
 
 const UIStrings = {
-  title: 'Digital Data Object `version` property is set.',
-  failureTitle:
-    'Digital Data Object Carbon for IBM.com `version` property is missing.',
+  title: 'Carbon for IBM.com version is up to date.',
+  failureTitle: 'Carbon for IBM.com version is outdated.',
   description:
     'This property shows what Carbon for IBM.com package is being used on a page, as well as the version. This information can be helpful in troubleshooting bugs when authoring with Carbon for IBM.com packages. [Learn more](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/building-for-ibm-dotcom.md#digital-data-object).',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const currentVersion = 20;
 
 /**
  * @file Audits if page contains the IBM Digital Data Object (DDO)
@@ -28,7 +29,7 @@ class DDOAudit extends Audit {
    */
   static get meta() {
     return {
-      id: 'ddo-version-audit',
+      id: 'ddo-version-check-audit',
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
@@ -45,12 +46,19 @@ class DDOAudit extends Audit {
     const loadMetrics = artifacts.CheckDDO.page.pageInfo.version;
     const hasVersion = typeof loadMetrics !== 'undefined';
 
+    const versionNumber = parseInt(loadMetrics.split(' ').pop().split('.')[1]);
+    const versionDiff = currentVersion - versionNumber;
+
     // binary scoring
-    const score = hasVersion ? 1 : 0;
+    const score = !versionDiff ? 1 : 0;
+    const displayString = versionDiff
+      ? `Carbon for IBM.com package is ${versionDiff} version behind`
+      : '';
 
     return {
       rawValue: hasVersion,
       score: Number(score),
+      displayValue: displayString,
     };
   }
 }

--- a/src/config/custom-config.js
+++ b/src/config/custom-config.js
@@ -36,6 +36,9 @@ const UIStrings = {
   /** Description of IBM.com page data audits. This is displayed at the top of a list of audits focused on IBM-specific meta data. */
   pageDataCategoryDescription:
     'These checks ensure that key data is being set on your page, such as the Digital Data Object, locale, meta, analytics, and cookie data.',
+  carbonForIBMDotcomTitle: 'Carbon for IBM.com',
+  carbonForIBMDotcomDescription:
+    'Carbon for IBM.com is the open source design system for IBM.com’s digital experiences. The system consists of working code, design tools, and resources and is tailored to IBM.com website page makers.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -43,7 +46,12 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 module.exports = {
   extends: 'lighthouse:default',
   settings: {
-    onlyCategories: ['legal', 'page-data', 'page-content'],
+    onlyCategories: [
+      'legal',
+      'page-data',
+      'page-content',
+      'carbon-for-ibm-dotcom',
+    ],
   },
   passes: [
     {
@@ -51,6 +59,8 @@ module.exports = {
       gatherers: [
         `${constants.paths.gatherer}/page-data/ddo/ddo-gatherer`,
         `${constants.paths.gatherer}/legal/legal-links-gatherer`,
+        `${constants.paths.gatherer}/carbon-for-ibm-dotcom/components-gatherer`,
+        `${constants.paths.gatherer}/carbon-for-ibm-dotcom/v18-gatherer`,
         // `${constants.paths.gatherer}/page-data/lang-attribute-gatherer`,
         // `${constants.paths.gatherer}/page-content/scripts-gatherer`,
       ],
@@ -60,10 +70,22 @@ module.exports = {
     `${constants.paths.audit}/page-data/ddo/ddo-country-audit`,
     `${constants.paths.audit}/page-data/ddo/ddo-language-audit`,
     `${constants.paths.audit}/page-data/ddo/ddo-version-audit`,
+    `${constants.paths.audit}/page-data/ddo/ddo-version-check-audit`,
     `${constants.paths.audit}/legal/cookie-preferences-audit`,
     `${constants.paths.audit}/legal/accessibility-link-audit`,
     `${constants.paths.audit}/legal/privacy-link-audit`,
     `${constants.paths.audit}/legal/terms-of-use-link-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/v18-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/masthead-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/footer-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/leadspace-heading-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/leadspace-description-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/content-block-heading-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/callout-quote-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/card-group-number-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/card-eyebrow-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/card-heading-audit`,
+    `${constants.paths.audit}/carbon-for-ibm-dotcom/card-copy-audit`,
     // `${constants.paths.audit}/page-data/lang-attribute-audit`,
   ],
   groups: {
@@ -79,6 +101,10 @@ module.exports = {
       title: UIStrings.northstarGroupTitle,
       description: str_(UIStrings.northstarGroupDescription),
     },
+    'carbon-for-ibm-dotcom': {
+      title: UIStrings.carbonForIBMDotcomTitle,
+      description: str_(UIStrings.carbonForIBMDotcomDescription),
+    },
   },
   categories: {
     'page-data': {
@@ -87,6 +113,11 @@ module.exports = {
         { id: 'ddo-country-audit', weight: 1, group: 'digital-data-object' },
         { id: 'ddo-language-audit', weight: 1, group: 'digital-data-object' },
         { id: 'ddo-version-audit', weight: 1, group: 'digital-data-object' },
+        {
+          id: 'ddo-version-check-audit',
+          weight: 3,
+          group: 'digital-data-object',
+        },
       ],
     },
     legal: {
@@ -111,6 +142,58 @@ module.exports = {
           id: 'terms-of-use-link-audit',
           weight: 1,
           group: 'legal',
+        },
+      ],
+    },
+    'carbon-for-ibm-dotcom': {
+      title: UIStrings.carbonForIBMDotcomTitle,
+      auditRefs: [
+        { id: 'masthead-audit', weight: 1, group: 'carbon-for-ibm-dotcom' },
+        { id: 'footer-audit', weight: 1, group: 'carbon-for-ibm-dotcom' },
+        {
+          id: 'leadspace-heading-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'leadspace-description-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'content-block-heading-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'callout-quote-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'card-group-number-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'card-eyebrow-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'card-heading-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'card-copy-audit',
+          weight: 1,
+          group: 'carbon-for-ibm-dotcom',
+        },
+        {
+          id: 'v18-audit',
+          weight: 3,
+          group: 'carbon-for-ibm-dotcom',
         },
       ],
     },

--- a/src/gatherers/carbon-for-ibm-dotcom/components-gatherer.js
+++ b/src/gatherers/carbon-for-ibm-dotcom/components-gatherer.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Gatherer = require('lighthouse').Gatherer;
+const pageFunctions = require('../../../node_modules/lighthouse/lighthouse-core/lib/page-functions.js');
+
+/**
+ * Gets the Carbon for IBM.com components in the DOM based off of the data-autoids
+ *
+ * @returns {Array} array of Carbon for IBM.com components
+ */
+function getComponentsInDOM() {
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
+  const browserElements = getElementsInDocument(`[data-autoid^='dds--']`); // eslint-disable-line no-undef
+  const components = [];
+
+  for (const element of browserElements) {
+    if (!(element instanceof HTMLElement)) continue;
+
+    const dataAutoid = element.getAttribute('data-autoid') || '';
+    components.push({
+      rel: element.rel,
+      href: element.href,
+      hreflang: element.hreflang,
+      as: element.as,
+      crossOrigin: element.crossOrigin,
+      innerText: element.innerText,
+      dataAutoid,
+      // @ts-expect-error - put into scope via stringification
+      // eslint-disable-next-line no-undef
+      node: getNodeDetails(element),
+    });
+  }
+  return components;
+}
+
+/**
+ * Gatherer to return Carbon for IBM.com Components on the page
+ */
+class CheckComponents extends Gatherer {
+  /**
+   * @param {object} passContext passContext object
+   * @returns {Promise} promise of elements from DOM
+   */
+  static getComponentsInDOM(passContext) {
+    // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize
+    // the values like access from JavaScript does.
+    return passContext.driver.executionContext.evaluate(getComponentsInDOM, {
+      args: [],
+      useIsolation: true,
+      deps: [
+        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+      ],
+    });
+  }
+
+  /**
+   * @param {object} options Gatherer options
+   * @returns {*} Gatherer artifact
+   */
+  async afterPass(options) {
+    const driver = await CheckComponents.getComponentsInDOM(options);
+    return driver;
+  }
+}
+
+module.exports = CheckComponents;

--- a/src/gatherers/carbon-for-ibm-dotcom/v18-gatherer.js
+++ b/src/gatherers/carbon-for-ibm-dotcom/v18-gatherer.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright IBM Corp. 2016, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const Gatherer = require('lighthouse').Gatherer;
+const pageFunctions = require('../../../node_modules/lighthouse/lighthouse-core/lib/page-functions.js');
+
+/**
+ * Gets the v18 scripts and classes that are loaded on the page
+ *
+ * @returns {Array} array of v18 classes loaded on the page
+ */
+function getScriptsInDom() {
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
+  const scriptsElements = getElementsInDocument(`script`); // eslint-disable-line no-undef
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
+  const classElements = getElementsInDocument(`[class^='ibm-']`); // eslint-disable-line no-undef
+  const components = [];
+  const classes = [];
+
+  const jsScript = '//1.www.s81c.com/common/v18/js/www.js';
+  const cssScript = '//1.www.s81c.com/common/v18/css/www.css';
+
+  for (const element of scriptsElements) {
+    if (!(element instanceof HTMLElement)) continue;
+
+    const src = element.src;
+
+    if (src.includes(jsScript) || src.includes(cssScript)) {
+      components.push({
+        src: src,
+      });
+    }
+  }
+
+  for (const element of classElements) {
+    if (!(element instanceof HTMLElement)) continue;
+    classes.push({
+      // @ts-expect-error - put into scope via stringification
+      // eslint-disable-next-line no-undef
+      snippet: getNodeDetails(element).snippet,
+    });
+  }
+
+  return !components ? null : classes;
+}
+
+/**
+ * Gatherer to return Northstar v18 classes loaded on the page
+ */
+class CheckV18 extends Gatherer {
+  /**
+   * @param {object} passContext passContext object
+   * @returns {Promise} promise of elements from DOM
+   */
+  static getScriptsInDom(passContext) {
+    // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize
+    // the values like access from JavaScript does.
+    return passContext.driver.executionContext.evaluate(getScriptsInDom, {
+      args: [],
+      useIsolation: true,
+      deps: [
+        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+      ],
+    });
+  }
+
+  /**
+   * @param {object} options Gatherer options
+   * @returns {*} Gatherer artifact
+   */
+  async afterPass(options) {
+    const driver = await CheckV18.getScriptsInDom(options);
+    return driver;
+  }
+}
+
+module.exports = CheckV18;


### PR DESCRIPTION
### Related Ticket(s)
[#5938](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5938)

### Description
Created audits for the Carbon for IBM.com bucket.

### Changelog

**New**

- created audits for Carbon for IBM.com bucket to audit certain components

**Changed**

- updated Carbon for IBM.com version audit to display how many versions behind it is

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
