### PR TITLE
chore(node): add node 14 support to engines list

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "beacon": "lighthouse --config-path=src/config/custom-config.js",
-    "ci-check": "format:diff && lint:src",
+    "ci-check": "npm run format:diff && yarn lint:src",
     "format": "prettier --write '**/*.{js,md}'",
     "format:diff": "prettier --list-different '**/*.{js,md}'",
     "lint": "yarn lint:src && yarn lint:dist",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/IBM/beacon-for-ibm-dotcom",
   "license": "Apache-2.0",
   "engines": {
-    "node": "12.x"
+    "node": "12 || 14"
   },
   "scripts": {
     "beacon": "lighthouse --config-path=src/config/custom-config.js",


### PR DESCRIPTION
### Description

Add support for Node `14.x`.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
