### PR TITLE
fix(i18n): update i18n module paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@carbon/beacon-for-ibm-dotcom",
+  "name": "beacon-for-ibm-dotcom",
   "description": "Beacon for IBM.com",
   "version": "0.1.0",
   "repository": "https://github.com/IBM/beacon-for-ibm-dotcom",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -14,13 +14,11 @@ const path = require('path');
  */
 const AUDIT_PATH = path.join(__dirname, '../audits');
 const GATHERER_PATH = path.join(__dirname, '../gatherers');
-const I18N_PATH = path.join(
-  __dirname,
-  '../../../lighthouse/lighthouse-core/lib/i18n/i18n.js'
+const I18N_PATH = require.resolve(
+  'lighthouse/lighthouse-core/lib/i18n/i18n.js'
 );
-const PAGE_FUNCTIONS = path.join(
-  __dirname,
-  '../../../lighthouse/lighthouse-core/lib/page-functions.js'
+const PAGE_FUNCTIONS = require.resolve(
+  'lighthouse/lighthouse-core/lib/page-functions.js'
 );
 
 const paths = {


### PR DESCRIPTION
### Description

Fixes an issue with Lighthouse i18n paths when installed locally.

### Changelog

**Changed**

- update `i18n` paths

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
