### PR TITLE
fix(beacon): token and message fixes

### DIFF
--- a/src/audits/carbon-design-system/color-usage-audit.js
+++ b/src/audits/carbon-design-system/color-usage-audit.js
@@ -128,7 +128,7 @@ class ColorUsageAudit extends Audit {
         let tokenValue = !str[1].startsWith('var')
           ? str[1]
           : str[1].match(/\,(.*)\)/)[1];
-        tokenValue = tokenValue.split('}')[0];
+        tokenValue = tokenValue.split('}')[0].trim();
         /* eslint-enable no-useless-escape */
 
         if (!tokenArray[str[0]]) tokenArray[str[0]] = [];

--- a/src/audits/carbon-design-system/text-usage-audit.js
+++ b/src/audits/carbon-design-system/text-usage-audit.js
@@ -194,11 +194,12 @@ class TextUsageAudit extends Audit {
           : str[1].match(/\,(.*)\)/)[1];
         /* eslint-enable no-useless-escape */
 
-        tokenValue = tokenValue.split('}')[0];
+        tokenValue = tokenValue.split('}')[0].trim();
 
         if (!tokenArray[str[0]]) tokenArray[str[0]] = [];
 
         if (tokenArray[str[0]].indexOf(tokenValue) === -1) {
+          if (tokenValue[0] === '.') tokenValue = `0${tokenValue}`;
           tokenArray[str[0]].push(tokenValue);
         }
       });
@@ -225,7 +226,7 @@ class TextUsageAudit extends Audit {
     }
 
     // binary scoring
-    const score = diffValues.length > 0 ? 0 : 1;
+    const score = diffValues.length ? 1 : 0;
 
     const displayString = diffValues
       ? `${diffValues} typograhy tokens with different values`

--- a/src/audits/page-data/ddo/ddo-version-check-audit.js
+++ b/src/audits/page-data/ddo/ddo-version-check-audit.js
@@ -53,7 +53,8 @@ class DDOAudit extends Audit {
   static audit(artifacts) {
     const loadMetrics = artifacts.CheckDDO.page.pageInfo.version;
     const hasVersion = typeof loadMetrics !== 'undefined';
-    const versionDiff = latestVersion !== loadMetrics;
+    const versionDiff =
+      latestVersion.split('v')[1] !== loadMetrics.split('v')[1];
 
     // binary scoring
     const score = !versionDiff ? 1 : 0;


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
There were some instances in which the scraped tokens matched the right ones and still marked a mismatch; this was due to an extra space. This PR ensures the strings are trimmed before comparison. 

This PR also fixes an error in which the Carbon for IBM.com version looks to be outdated even though its the latest. This was due to the way we're now fetching the latest version (which retrieved it as "Carbon for IBM.com vx.x.x" compared to just the "vx.x.x." part) and updated the string comparison.

### Changelog

**Changed**

- fixed some checks with to string trimming/parsing

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
