### PR TITLE
chore(publish): disable dry-run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          dry-run: true
+          dry-run: false
       - name: Create changelog
         if: steps.publish.outputs.version != steps.publish.outputs['old-version']
         env:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The publish workflow was set up as a dry-run for some reason. This will enable actual publishing.

### Changelog

**Changed**

- publish.yml

