### PR TITLE
chore(publish): fix for publishing scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "bin": {
     "beacon": "./cli.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "beacon": "lighthouse --config-path=src/config/custom-config.js",
     "ci-check": "npm run format:diff && yarn lint:src",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Since it is a scoped package. need to add an additional config to `package.json` for public publishing.

### Changelog

**Changed**

- `package.json`
