### PR TITLE
fix(audit): cookie preferences link audit

### DIFF
--- a/src/audits/legal/cookie-preferences-audit.js
+++ b/src/audits/legal/cookie-preferences-audit.js
@@ -43,7 +43,7 @@ class LegalLinksAudit extends Audit {
    */
   static audit(artifacts) {
     const loadMetrics = artifacts.CheckLegalLinks.filter((link) => {
-      return link.dataAutoid === 'dds--privacy-cp__link';
+      return link.dataAutoid === 'dds--privacy-cp';
     });
     const hasCookiePreferences = loadMetrics.length !== 0;
 

--- a/src/gatherers/legal/legal-links-gatherer.js
+++ b/src/gatherers/legal/legal-links-gatherer.js
@@ -17,14 +17,16 @@ const pageFunctions = require(constants.paths.pageFunctions);
  */
 function getLegalLinksInDOM() {
   // @ts-expect-error - getElementsInDocument put into scope via stringification
-  const browserElements = getElementsInDocument('a'); // eslint-disable-line no-undef
+  const browserElements = document.querySelectorAll(
+    '.bx--legal-nav__holder [data-autoid]'
+  );
   const linkElements = [];
 
   for (const link of browserElements) {
     if (!(link instanceof HTMLElement)) continue;
 
     const hrefRaw = link.getAttribute('href') || '';
-    const dataAutoid = link.getAttribute('data-autoid') || '';
+    const dataAutoid = link.dataset.autoid || '';
     const source = link.closest('head') ? 'head' : 'body';
 
     // check if the data-autoid is one of a legal link or specifically the cookie preferences link
@@ -32,7 +34,7 @@ function getLegalLinksInDOM() {
       dataAutoid === 'dds--footer-legal-nav__link-privacy' ||
       dataAutoid === 'dds--footer-legal-nav__link-terms-of-use' ||
       dataAutoid === 'dds--footer-legal-nav__link-accessibility' ||
-      dataAutoid === 'dds--privacy-cp__link'
+      dataAutoid === 'dds--privacy-cp'
     ) {
       linkElements.push({
         rel: link.rel,
@@ -67,10 +69,7 @@ class CheckLegalLinks extends Gatherer {
     return passContext.driver.executionContext.evaluate(getLegalLinksInDOM, {
       args: [],
       useIsolation: true,
-      deps: [
-        pageFunctions.getNodeDetailsString,
-        pageFunctions.getElementsInDocument,
-      ],
+      deps: [pageFunctions.getNodeDetailsString],
     });
   }
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/IBM/beacon-for-ibm-dotcom/issues/26

### Description

Fixes the `cookie preferences` link gatherer, which was not detecting the link because `data-autoid` is on the wrong element.

![image](https://user-images.githubusercontent.com/909118/137807356-33d46845-129f-4cd6-9951-3e19e4633f7a.png)


### Changelog

**Changed**

- update selector for footer legal link elements

**Removed**

- `getElementsInDocument()` is no longer needed

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
