### PR TITLE
fix(chrome): adding `--no-sandbox` flag for chromebrowser

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (args) => {
 async function runLightHouse(args) {
   try {
     const chrome = await chromeLauncher.launch({
-      chromeFlags: ['--headless', '--disable-dev-shm-usage'],
+      chromeFlags: ['--headless', '--disable-dev-shm-usage', '--no-sandbox'],
     });
     const options = {
       logLevel: 'info',

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (args) => {
 async function runLightHouse(args) {
   try {
     const chrome = await chromeLauncher.launch({
-      chromeFlags: ['--headless', '--disable-dev-shm-usage', '--no-sandbox'],
+      chromeFlags: ['--headless', '--disable-gpu', '--no-sandbox'],
     });
     const options = {
       logLevel: 'info',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/beacon",
   "description": "Beacon for IBM.com",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "repository": "https://github.com/IBM/beacon-for-ibm-dotcom",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/IBM/beacon-for-ibm-dotcom/issues/42

### Description

There are connection issues with headless chrome on cloud foundry. This additional flag for opening Chrome may solve the issue.

This will also bump a patch release of `0.4.1`.

### Changelog

**Changed**

- add `--no-sandbox` flag to `chromeLauncher.launch` flags
- bump version in `package.json` to `0.4.1` 