### PR TITLE
fix(chrome): add `--disable-setuid-sandbox` flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ module.exports = (args) => {
 async function runLightHouse(args) {
   try {
     const chrome = await chromeLauncher.launch({
-      chromeFlags: ['--headless', '--disable-gpu', '--no-sandbox'],
+      chromeFlags: [
+        '--headless',
+        '--disable-gpu',
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--enable-logging',
+      ],
     });
     const options = {
       logLevel: 'info',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/beacon",
   "description": "Beacon for IBM.com",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": "https://github.com/IBM/beacon-for-ibm-dotcom",
   "license": "Apache-2.0",
   "engines": {
@@ -39,6 +39,7 @@
     "@commitlint/config-conventional": "^12.1.1",
     "@formatjs/icu-messageformat-parser": "1.1.5",
     "babel-eslint": "10.1.0",
+    "chrome-launcher": "^0.15.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-airbnb-base": "14.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,16 @@ chrome-launcher@^0.14.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
+chrome-launcher@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.15.0.tgz#5144a57aba0cf2f4cbe61dccefdde024fb3ca7fc"
+  integrity sha512-ZQqX5kb9H0+jy1OqLnWampfocrtSZaGl7Ny3F9GRha85o4odbL8x55paUzh51UC7cEmZ5obp3H2Mm70uC2PpRA==
+  dependencies:
+    "@types/node" "*"
+    escape-string-regexp "^4.0.0"
+    is-wsl "^2.2.0"
+    lighthouse-logger "^1.0.0"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"


### PR DESCRIPTION
### Related Ticket(s)

Refs #42 

### Description

This adds an additional flag `--disable-setuid-sandbox` when launching Chrome. In addition, the `chrome-launcher` package was missing.

This will bump to release `0.4.2`.

### Changelog

**Changed**

- Add `chrome-launcher` package
- Add additional chrome launcher flag
- Bump to version `0.4.2` in `package.json`
