### PR TITLE
fix(chrome): add flag for fixing chrome in docker

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function runLightHouse(args) {
         '--headless',
         '--disable-gpu',
         '--no-sandbox',
-        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
         '--enable-logging',
       ],
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/beacon",
   "description": "Beacon for IBM.com",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": "https://github.com/IBM/beacon-for-ibm-dotcom",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### Related Ticket(s)

Ref #42 

### Description

The beacon/lighthouse tool running in Docker is running a bit slow, hoping this flag adjustment will fix the issues.

This will bump beacon to `0.4.3`.

### Changelog

**Changed**

- Added flag `--disable-dev-shm-usage` to chrome launcher
- Bump version to `0.4.3`
